### PR TITLE
Add enemy state machine with idle, wander, and chase behaviors

### DIFF
--- a/Character/Enemy/States/chase_state.gd
+++ b/Character/Enemy/States/chase_state.gd
@@ -1,0 +1,41 @@
+extends EnemyState
+class_name EnemyChaseState
+
+@export var speed: float = 3.0
+@export var attack_range: float = 1.5
+@export var player_ray_path: NodePath
+@export var lost_state: StringName = "IdleState"
+
+var player_ray: RayCast3D
+var player: Player
+var attack_range_sq: float
+
+func enter() -> void:
+    player_ray = enemy.get_node(player_ray_path) as RayCast3D
+    attack_range_sq = attack_range * attack_range
+
+func physics_update(_delta: float) -> void:
+    if not _acquire_player():
+        state_component.transition_to(lost_state)
+        return
+    var to_player: Vector3 = player.global_position - enemy.global_position
+    var dist_sq: float = to_player.length_squared()
+    if dist_sq <= attack_range_sq:
+        enemy.attack(player)
+        return
+    var dir: Vector3 = to_player.normalized()
+    enemy.velocity.x = dir.x * speed
+    enemy.move_and_slide()
+    if player_ray:
+        var sign_x = dir.x >= 0 ? 1.0 : -1.0
+        player_ray.target_position.x = sign_x * abs(player_ray.target_position.x)
+
+func _acquire_player() -> bool:
+    if player_ray and player_ray.is_colliding():
+        var collider = player_ray.get_collider()
+        if collider is Player:
+            player = collider
+    return player != null and is_instance_valid(player)
+
+func exit() -> void:
+    enemy.velocity = Vector3.ZERO

--- a/Character/Enemy/States/idle_state.gd
+++ b/Character/Enemy/States/idle_state.gd
@@ -1,0 +1,31 @@
+extends EnemyState
+class_name EnemyIdleState
+
+@export var min_wait: float = 1.0
+@export var max_wait: float = 2.0
+@export var next_state: StringName = "WanderState"
+@export var player_ray_path: NodePath
+
+var timer: Timer
+var player_ray: RayCast3D
+
+func enter() -> void:
+    enemy.velocity = Vector3.ZERO
+    if player_ray_path:
+        player_ray = enemy.get_node(player_ray_path) as RayCast3D
+    if timer:
+        timer.queue_free()
+    timer = Timer.new()
+    timer.wait_time = randf_range(min_wait, max_wait)
+    timer.one_shot = true
+    timer.timeout.connect(func(): state_component.transition_to(next_state))
+    add_child(timer)
+    timer.start()
+
+func physics_update(_delta: float) -> void:
+    if player_ray and player_ray.is_colliding() and player_ray.get_collider() is Player:
+        state_component.transition_to("ChaseState")
+
+func exit() -> void:
+    if timer:
+        timer.queue_free()

--- a/Character/Enemy/States/wander_state.gd
+++ b/Character/Enemy/States/wander_state.gd
@@ -1,0 +1,66 @@
+extends EnemyState
+class_name EnemyWanderState
+
+@export var speed: float = 2.0
+@export var move_time: float = 2.0
+@export var next_state: StringName = "IdleState"
+@export var wall_ray_path: NodePath
+@export var floor_ray_path: NodePath
+@export var player_ray_path: NodePath
+
+var direction: float = 1.0
+var timer: Timer
+var wall_ray: RayCast3D
+var floor_ray: RayCast3D
+var player_ray: RayCast3D
+var wall_target_x: float
+var floor_target_x: float
+var floor_position_x: float
+var floor_target_y: float
+var player_target_x: float
+
+func enter() -> void:
+    direction = randf() < 0.5 ? -1.0 : 1.0
+    wall_ray = enemy.get_node(wall_ray_path) as RayCast3D
+    floor_ray = enemy.get_node(floor_ray_path) as RayCast3D
+    if player_ray_path:
+        player_ray = enemy.get_node(player_ray_path) as RayCast3D
+    wall_target_x = abs(wall_ray.target_position.x)
+    floor_target_x = abs(floor_ray.target_position.x)
+    floor_position_x = abs(floor_ray.position.x)
+    floor_target_y = floor_ray.target_position.y
+    if player_ray:
+        player_target_x = abs(player_ray.target_position.x)
+    if timer:
+        timer.queue_free()
+    timer = Timer.new()
+    timer.wait_time = move_time
+    timer.one_shot = true
+    timer.timeout.connect(func(): state_component.transition_to(next_state))
+    add_child(timer)
+    timer.start()
+    _update_rays()
+
+func _update_rays() -> void:
+    wall_ray.target_position.x = direction * wall_target_x
+    floor_ray.position.x = direction * floor_position_x
+    floor_ray.target_position.x = direction * floor_target_x
+    floor_ray.target_position.y = floor_target_y
+    if player_ray:
+        player_ray.target_position.x = direction * player_target_x
+
+func physics_update(delta: float) -> void:
+    _update_rays()
+    if player_ray and player_ray.is_colliding() and player_ray.get_collider() is Player:
+        state_component.transition_to("ChaseState")
+        return
+    if wall_ray.is_colliding() or not floor_ray.is_colliding():
+        direction *= -1.0
+        _update_rays()
+    enemy.velocity.x = direction * speed
+    enemy.move_and_slide()
+
+func exit() -> void:
+    enemy.velocity = Vector3.ZERO
+    if timer:
+        timer.queue_free()

--- a/Character/Enemy/enemy.gd
+++ b/Character/Enemy/enemy.gd
@@ -1,0 +1,26 @@
+extends CharacterBody3D
+class_name Enemy
+
+@onready var health_component: HealthComponent = get_node_or_null("HealthComponent")
+@onready var state_component: StateComponent = get_node_or_null("StateComponent")
+
+func _ready() -> void:
+    add_to_group("enemies")
+    if health_component:
+        health_component.died.connect(_on_died)
+    else:
+        push_warning("Enemy missing HealthComponent")
+    if not state_component:
+        push_warning("Enemy missing StateComponent")
+
+func take_damage(amount: int) -> void:
+    if health_component:
+        health_component.take_damage(amount)
+
+func attack(target: Player) -> void:
+    var target_health: HealthComponent = target.get_node_or_null("HealthComponent")
+    if target_health:
+        target_health.take_damage(1)
+
+func _on_died() -> void:
+    queue_free()

--- a/Character/Enemy/enemy.tscn
+++ b/Character/Enemy/enemy.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=7 format=3]
+
+[ext_resource type="Script" path="res://Character/Enemy/enemy.gd" id="1"]
+[ext_resource type="PackedScene" path="res://Components/health_component.tscn" id="2"]
+[ext_resource type="Script" path="res://Character/Enemy/state_component.gd" id="3"]
+[ext_resource type="Script" path="res://Character/Enemy/States/idle_state.gd" id="4"]
+[ext_resource type="Script" path="res://Character/Enemy/States/wander_state.gd" id="5"]
+[ext_resource type="Script" path="res://Character/Enemy/States/chase_state.gd" id="6"]
+
+[node name="Enemy" type="CharacterBody3D" script=ExtResource("1")]
+
+[node name="VisibleOnScreenEnabler3D" type="VisibleOnScreenEnabler3D" parent="."]
+
+[node name="HealthComponent" parent="." instance=ExtResource("2")]
+
+[node name="WallCheck" type="RayCast3D" parent="."]
+target_position = Vector3(1, 0, 0)
+
+[node name="FloorCheck" type="RayCast3D" parent="."]
+position = Vector3(0.5, 0, 0)
+target_position = Vector3(0.5, -1, 0)
+
+[node name="PlayerCheck" type="RayCast3D" parent="."]
+target_position = Vector3(5, 0, 0)
+
+[node name="StateComponent" type="Node" parent="." script=ExtResource("3")]
+initial_state = "IdleState"
+
+[node name="IdleState" type="Node" parent="StateComponent" script=ExtResource("4")]
+next_state = "WanderState"
+player_ray_path = NodePath("PlayerCheck")
+
+[node name="WanderState" type="Node" parent="StateComponent" script=ExtResource("5")]
+wall_ray_path = NodePath("WallCheck")
+floor_ray_path = NodePath("FloorCheck")
+next_state = "IdleState"
+player_ray_path = NodePath("PlayerCheck")
+
+[node name="ChaseState" type="Node" parent="StateComponent" script=ExtResource("6")]
+player_ray_path = NodePath("PlayerCheck")

--- a/Character/Enemy/enemy_state.gd
+++ b/Character/Enemy/enemy_state.gd
@@ -1,0 +1,14 @@
+extends Node
+class_name EnemyState
+
+var enemy: Enemy
+var state_component: StateComponent
+
+func enter() -> void:
+    pass
+
+func exit() -> void:
+    pass
+
+func physics_update(delta: float) -> void:
+    pass

--- a/Character/Enemy/state_component.gd
+++ b/Character/Enemy/state_component.gd
@@ -1,0 +1,33 @@
+extends Node
+class_name StateComponent
+
+@export var initial_state: StringName
+
+var state: EnemyState
+
+func _ready() -> void:
+    for child in get_children():
+        if child is EnemyState:
+            child.enemy = owner
+            child.state_component = self
+    if initial_state != StringName():
+        state = get_node_or_null(initial_state) as EnemyState
+        if state:
+            state.enter()
+        else:
+            push_warning("Initial state '%s' not found" % initial_state)
+    set_physics_process(true)
+
+func transition_to(name: StringName) -> void:
+    var new_state: EnemyState = get_node_or_null(name) as EnemyState
+    if new_state:
+        if state:
+            state.exit()
+        state = new_state
+        state.enter()
+    else:
+        push_warning("State '%s' not found" % name)
+
+func _physics_process(delta: float) -> void:
+    if state:
+        state.physics_update(delta)


### PR DESCRIPTION
## Summary
- add chase state that pursues the player and attacks at close range
- wire idle and wander states to detect the player via raycast and transition to chase
- extend enemy scene with player detection raycast and attack capability

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f2c198083308baf9f807eff643a