### PR TITLE
Fix enemy facing direction during wandering

### DIFF
--- a/Character/Enemy/States/chase_state.gd
+++ b/Character/Enemy/States/chase_state.gd
@@ -23,12 +23,13 @@ func physics_update(_delta: float) -> void:
 	if dist_sq <= attack_range_sq:
 		enemy.attack(player)
 		return
-	var dir: Vector3 = to_player.normalized()
-	enemy.velocity.x = dir.x * speed
-	enemy.move_and_slide()
-	if player_ray:
-		var sign_x: float = sign(dir.x)
-		player_ray.target_position.x = sign_x * abs(player_ray.target_position.x)
+        var dir: Vector3 = to_player.normalized()
+        enemy.set_facing_right(dir.x > 0)
+        enemy.velocity.x = dir.x * speed
+        enemy.move_and_slide()
+        if player_ray:
+                var sign_x: float = sign(dir.x)
+                player_ray.target_position.x = sign_x * abs(player_ray.target_position.x)
 
 func _acquire_player() -> bool:
 	if player_ray and player_ray.is_colliding():

--- a/Character/Enemy/States/wander_state.gd
+++ b/Character/Enemy/States/wander_state.gd
@@ -18,43 +18,45 @@ var floor_target_y: float
 var player_target_x: float
 
 func enter() -> void:
-	direction = sign(randf())
-	wall_target_x = abs(wall_ray.target_position.x)
-	floor_target_x = abs(floor_ray.target_position.x)
-	floor_position_x = abs(floor_ray.position.x)
-	floor_target_y = floor_ray.target_position.y
-	if player_ray:
-		player_target_x = abs(player_ray.target_position.x)
-	if timer:
-		timer.queue_free()
-	timer = Timer.new()
-	timer.wait_time = move_time
-	timer.one_shot = true
-	timer.timeout.connect(func(): state_component.transition_to(idle_state))
-	add_child(timer)
-	timer.start()
-	_update_rays()
+    direction = randf() < 0.5 ? -1.0 : 1.0
+    wall_target_x = abs(wall_ray.target_position.x)
+    floor_target_x = abs(floor_ray.target_position.x)
+    floor_position_x = abs(floor_ray.position.x)
+    floor_target_y = floor_ray.target_position.y
+    if player_ray:
+        player_target_x = abs(player_ray.target_position.x)
+    if timer:
+        timer.queue_free()
+    timer = Timer.new()
+    timer.wait_time = move_time
+    timer.one_shot = true
+    timer.timeout.connect(func(): state_component.transition_to(idle_state))
+    add_child(timer)
+    timer.start()
+    _update_rays()
+    enemy.set_facing_right(direction > 0)
 
 func _update_rays() -> void:
-	wall_ray.target_position.x = direction * wall_target_x
-	floor_ray.position.x = direction * floor_position_x
-	floor_ray.target_position.x = direction * floor_target_x
-	floor_ray.target_position.y = floor_target_y
-	if player_ray:
-		player_ray.target_position.x = direction * player_target_x
+    wall_ray.target_position.x = direction * wall_target_x
+    floor_ray.position.x = direction * floor_position_x
+    floor_ray.target_position.x = direction * floor_target_x
+    floor_ray.target_position.y = floor_target_y
+    if player_ray:
+        player_ray.target_position.x = direction * player_target_x
 
 func physics_update(_delta: float) -> void:
-	_update_rays()
-	if player_ray and player_ray.is_colliding() and player_ray.get_collider() is Player:
-		state_component.transition_to(chase_state)
-		return
-	if wall_ray.is_colliding() or not floor_ray.is_colliding():
-		direction *= -1.0
-		_update_rays()
-	enemy.velocity.x = direction * speed
-	enemy.move_and_slide()
+    _update_rays()
+    if player_ray and player_ray.is_colliding() and player_ray.get_collider() is Player:
+        state_component.transition_to(chase_state)
+        return
+    if wall_ray.is_colliding() or not floor_ray.is_colliding():
+        direction *= -1.0
+        _update_rays()
+        enemy.set_facing_right(direction > 0)
+    enemy.velocity.x = direction * speed
+    enemy.move_and_slide()
 
 func exit() -> void:
-	enemy.velocity = Vector3.ZERO
-	if timer:
-		timer.queue_free()
+    enemy.velocity = Vector3.ZERO
+    if timer:
+        timer.queue_free()

--- a/Character/Enemy/enemy.gd
+++ b/Character/Enemy/enemy.gd
@@ -3,6 +3,7 @@ class_name Enemy
 
 @onready var health_component: HealthComponent = get_node_or_null("HealthComponent")
 @onready var state_component: StateComponent = get_node_or_null("StateComponent")
+@onready var rotation_handle: Node3D = get_node_or_null("RotationHandle")
 
 func _ready() -> void:
 	add_to_group("enemies")
@@ -31,9 +32,13 @@ func take_damage(amount: int) -> void:
 		health_component.take_damage(amount)
 
 func attack(target: Player) -> void:
-	var target_health: HealthComponent = target.get_node_or_null("HealthComponent")
-	if target_health:
-		target_health.take_damage(1)
+        var target_health: HealthComponent = target.get_node_or_null("HealthComponent")
+        if target_health:
+                target_health.take_damage(1)
 
 func _on_died() -> void:
-	queue_free()
+        queue_free()
+
+func set_facing_right(facing_right: bool) -> void:
+        if rotation_handle:
+                rotation_handle.rotation.y = 0 if facing_right else PI

--- a/Character/Enemy/enemy.tscn
+++ b/Character/Enemy/enemy.tscn
@@ -9,6 +9,8 @@
 
 [node name="Enemy" type="CharacterBody3D" script=ExtResource("1")]
 
+[node name="RotationHandle" type="Node3D" parent="."]
+
 [node name="VisibleOnScreenEnabler3D" type="VisibleOnScreenEnabler3D" parent="."]
 
 [node name="HealthComponent" parent="." instance=ExtResource("2")]

--- a/Character/SlimeMonster/slime_monster.tscn
+++ b/Character/SlimeMonster/slime_monster.tscn
@@ -16,7 +16,9 @@ height = 0.6
 axis_lock_linear_z = true
 script = ExtResource("1")
 
-[node name="Mesh" parent="." instance=ExtResource("2_j5ho3")]
+[node name="RotationHandle" type="Node3D" parent="."]
+
+[node name="Mesh" parent="RotationHandle" instance=ExtResource("2_j5ho3")]
 transform = Transform3D(-2.98023e-08, 0, -1, 0, 1, 0, 1, 0, -2.98023e-08, 0, 0, 0)
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]


### PR DESCRIPTION
## Summary
- Add `RotationHandle` to enemy scenes and rotate it to face movement
- Update wander and chase states to call new facing helper
- Centralize visual flipping with `Enemy.set_facing_right`

## Testing
- `godot3-server --version`


------
https://chatgpt.com/codex/tasks/task_e_689cc038d95883309b2b4ebf9184510e